### PR TITLE
Solve crash when not using Arc

### DIFF
--- a/BButton/BButton.m
+++ b/BButton/BButton.m
@@ -29,6 +29,10 @@
     if (_gradient != NULL) {
         CGGradientRelease(_gradient);
     }
+	
+#if !__has_feature(objc_arc)
+	[super dealloc];
+#endif
 }
 
 - (id) initWithFrame:(CGRect)frame {
@@ -60,7 +64,13 @@
 }
 
 - (void) setColor:(UIColor *)color {
-    _color = color;
+#if __has_feature(objc_arc)
+	_color = color;
+#else
+	if (_color)
+		[_color release];
+    _color = [color retain];
+#endif
     
     if ([self isLightColor:color]) {
         [self setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
@@ -79,9 +89,14 @@
     CGFloat newGradientLocations[] = {0.0, 1.0};
     
     CGGradientRelease(_gradient);
-    _gradient = CGGradientCreateWithColors(colorSpace, (__bridge CFArrayRef)newGradientColors, newGradientLocations);
+	
+#if __has_feature(objc_arc)
+	_gradient = CGGradientCreateWithColors(colorSpace, (__bridge CFArrayRef)newGradientColors, newGradientLocations);
+#else
+    _gradient = CGGradientCreateWithColors(colorSpace, (CFArrayRef)newGradientColors, newGradientLocations);
+#endif
+
     CGColorSpaceRelease(colorSpace);
-    
     [self setNeedsDisplay];
 }
 


### PR DESCRIPTION
Hi,

I really like your BButton and since it crashed when I tried to click on a Button I looked for a way to solve this (I found your project via cocoatrols when looking for bootstrap style button in iOS).

The main problem was due to the fact you may have tested using Arc. Due to the way the memory is managed with Arc it might not cause any problem but if you don't use it crashes may occur.

I changed a few lines (the most important one is the UIColor not being retained with Arc disabled). I fixed some warning when not using Arc and it seems now that your project works in both Arc and No-Arc projects.

I hope you'll accept this request.
Best regards.
Olivier
