### PR TITLE
Suppress `Implicit conversion loses integer precision` compiler warning.

### DIFF
--- a/BButton/UIColor+BButton.m
+++ b/BButton/UIColor+BButton.m
@@ -41,7 +41,7 @@
 
 - (UIColor *)lightenColorWithValue:(CGFloat)value
 {
-    int totalComponents = CGColorGetNumberOfComponents(self.CGColor);
+    size_t totalComponents = CGColorGetNumberOfComponents(self.CGColor);
     BOOL isGreyscale = (totalComponents == 2) ? YES : NO;
     
     CGFloat *oldComponents = (CGFloat *)CGColorGetComponents(self.CGColor);
@@ -72,7 +72,7 @@
 
 - (UIColor *)darkenColorWithValue:(CGFloat)value
 {
-    int totalComponents = CGColorGetNumberOfComponents(self.CGColor);
+    size_t totalComponents = CGColorGetNumberOfComponents(self.CGColor);
     BOOL isGreyscale = (totalComponents == 2) ? YES : NO;
     
     CGFloat *oldComponents = (CGFloat *)CGColorGetComponents(self.CGColor);
@@ -103,7 +103,7 @@
 
 - (BOOL)isLightColor
 {
-    int totalComponents = CGColorGetNumberOfComponents(self.CGColor);
+    size_t totalComponents = CGColorGetNumberOfComponents(self.CGColor);
     BOOL isGreyscale = (totalComponents == 2) ? YES : NO;
     
     CGFloat *components = (CGFloat *)CGColorGetComponents(self.CGColor);


### PR DESCRIPTION
Hi mattlawer,
I got `Implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int'` compiler warning when I built BButton (without CocoaPods).

To get the compiler warning, Try the following steps:
1. Open BButtonDemo project on Xcode-6.1.1
2. Open `Build Settings` of BButtonDemo and change `Build Active Architecture Only` to `NO` (It required to ship the App to AppStore with 64bit binary. See http://stackoverflow.com/questions/26790554/ios-app-submission-missing-64-bit-support for more details.)
3. Build the BButtonDemo project

Regards
